### PR TITLE
Add the ability to specify the stream to emit on from spouts.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,10 @@ GEM
     method_source (0.8.2)
     mime-types (1.23)
     multi_json (1.7.7)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     pry (0.10.1-java)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -48,6 +52,7 @@ GEM
 
 PLATFORMS
   java
+  ruby
 
 DEPENDENCIES
   coveralls

--- a/lib/red_storm/dsl/spout.rb
+++ b/lib/red_storm/dsl/spout.rb
@@ -77,6 +77,14 @@ module RedStorm
       end
       alias_method :emit, :unreliable_emit
 
+      def reliable_stream_emit(stream, message_id, *values)
+        @collector.emit(stream, Values.new(*values), message_id)
+      end
+
+      def unreliable_stream_emit(stream, *values)
+        @collector.emit(stream, Values.new(*values))
+      end
+
       # Spout proxy interface
 
       def next_tuple


### PR DESCRIPTION
Adds reliable_stream_emit and unreliable_stream_emit methods to the spout DSL.
